### PR TITLE
Changed ordering of module system usage: first Angular, then AMD

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,13 @@
   var isCommonJS = typeof exports === 'object';
   var isAngular = typeof angular === 'object';
 
+  // Angular
+  if (isAngular) {
+    _provider_ = factory((root.crypto || root.msCrypto));
+    angular.module(module_name, []).factory(property_name, [_provider_]);
+  }
   // AMD
-  if (isAMD) {
+  else if (isAMD) {
     define(['angular', 'crypto'], function (angular, crypto) {
       _provider_ = factory(crypto);
       return angular.module(module_name, []).factory(property_name, [_provider_]);
@@ -21,11 +26,6 @@
     if (isAngular) {
       module.exports[module_name] = angular.module(module_name, []).factory(property_name, [_provider_]);
     }
-  }
-  // Angular
-  else if (isAngular) {
-    _provider_ = factory((root.crypto || root.msCrypto));
-    angular.module(module_name, []).factory(property_name, [_provider_]);
   }
   // Global
   else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,16 @@
   var isCommonJS = typeof exports === 'object';
   var isAngular = typeof angular === 'object';
 
+  // CommonJS
+  if (isCommonJS) {
+    _provider_ = factory(require('crypto'));
+    module.exports[property_name] = _provider_;
+    if (isAngular) {
+      module.exports[module_name] = angular.module(module_name, []).factory(property_name, [_provider_]);
+    }
+  }
   // Angular
-  if (isAngular) {
+  else if (isAngular) {
     _provider_ = factory((root.crypto || root.msCrypto));
     angular.module(module_name, []).factory(property_name, [_provider_]);
   }
@@ -18,14 +26,6 @@
       _provider_ = factory(crypto);
       return angular.module(module_name, []).factory(property_name, [_provider_]);
     });
-  }
-  // CommonJS
-  else if (isCommonJS) {
-    _provider_ = factory(require('crypto'));
-    module.exports[property_name] = _provider_;
-    if (isAngular) {
-      module.exports[module_name] = angular.module(module_name, []).factory(property_name, [_provider_]);
-    }
   }
   // Global
   else {


### PR DESCRIPTION
In our application, the previous ordering tried to require('crypto'), while Angular provided it already, so it seemed logical to try the Angular way first.
